### PR TITLE
Fix multiple editions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trostani",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A Typescript Discord bot knowing stuff about MtG",
   "repository": "git@github.com:papey/trostani.git",
   "author": "papey",

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import * as yargs from "yargs";
 // Args and cli setup
 let args = yargs
   .scriptName("Trostani")
-  .version("0.2.1")
+  .version("0.2.2")
   .help()
   .option("config", {
     alias: "c",

--- a/src/scry/mtg.ts
+++ b/src/scry/mtg.ts
@@ -35,6 +35,11 @@ export class Card {
     return this.times;
   }
 
+  // Get edition
+  public getEdition(): string {
+    return this.edition.toUpperCase();
+  }
+
   // Try to get a translation for card from scryfall
   public async translate() {
     try {
@@ -116,7 +121,7 @@ export class Deck {
     // Check main length, needs to be a least > 0
     if (this.main.length > 0) {
       this.main.forEach((card) => {
-        let line: string = `${card.getTimes()} ${card.getFirstPartName()}\n`;
+        let line: string = `${card.getTimes()} ${card.getFirstPartName()} (${card.getEdition()})\n`;
         decklist += line;
       });
     }
@@ -125,7 +130,7 @@ export class Deck {
     if (this.side.length > 0) {
       decklist += "Sideboard: \n";
       this.side.forEach((card) => {
-        let line: string = `${card.getTimes()} ${card.getFirstPartName()}\n`;
+        let line: string = `${card.getTimes()} ${card.getFirstPartName()} (${card.getEdition()})\n`;
         decklist += line;
       });
     }

--- a/tests/mtg.test.ts
+++ b/tests/mtg.test.ts
@@ -36,11 +36,11 @@ class MTGDeckTestSuite extends Deck {
 
     let splited = list.split("\n");
 
-    assert.equal(splited[0], "4 Steam Vents");
-    assert.equal(splited[23], "3 Fabled Passage");
+    assert.equal(splited[0], "4 Steam Vents (GRN)");
+    assert.equal(splited[23], "3 Fabled Passage (ELD)");
     assert.equal(splited[24], "Sideboard: ");
-    assert.equal(splited[25], "1 Jace, Wielder of Mysteries");
-    assert.equal(splited[27], "1 Tamiyo, Collector of Tales");
+    assert.equal(splited[25], "1 Jace, Wielder of Mysteries (WAR)");
+    assert.equal(splited[27], "1 Tamiyo, Collector of Tales (WAR)");
     assert.equal(splited[29], "");
     assert.equal(splited.length, 30);
   }


### PR DESCRIPTION
This PR fixes a bug when a user commit a deck with same card from multiple editions.

This simply add the edition at the end of the line when exporting to Manastack.