### PR TITLE
fix(translate): cmd crash if translation list is empty (example: side…

### DIFF
--- a/src/scry/mtg.ts
+++ b/src/scry/mtg.ts
@@ -271,6 +271,9 @@ class Deck {
 
   // Take an entire deck part and translate it
   protected async translator(...parts: Card[]) {
+    if (parts.length === 0) {
+      return;
+    }
     // prepare collection
     const collection = parts.map((c) =>
       CardIdentifier.bySet(c.getEdition(), c.getID())


### PR DESCRIPTION
… is not mandatory)


Hello !!
I test Ur bot, so i have crash when set deck without side, example cmd : 
$tnmt join toto
Deck
2 Thrashing Brontodon (M21) 209
2 Kogla, the Titan Ape (IKO) 162
3 Feasting Troll King (ELD) 152
4 Lovestruck Beast (ELD) 165
4 Kazandu Mammoth (ZNR) 189
4 Tangled Florahedron (ZNR) 211
4 Gilded Goose (ELD) 160
4 Wicked Wolf (ELD) 181
2 Witch's Oven (ELD) 237
4 The Great Henge (ELD) 161
1 Wolfwillow Haven (THB) 205
3 Trail of Crumbs (ELD) 179
1 Vivien, Monsters' Advocate (IKO) 175
2 Crawling Barrens (ZNR) 262
2 Bonders' Enclave (IKO) 245
4 Castle Garenbrig (ELD) 240
14 Forest (KLR) 300

Side is not mandatory on mtg and your constraint check length between 0 to 50 
so if lentgh is 0 script block on translation. 

BR !