### PR TITLE
fix(Archidekt): Use email instead of name as login payload

### DIFF
--- a/src/builders/archidekt.ts
+++ b/src/builders/archidekt.ts
@@ -42,7 +42,7 @@ export class Archidekt implements Builder {
   // User login
   async login(): Promise<boolean> {
     await axios.post(`${this.url}/${this.routes["login"]}`, {
-      username: this.user.name,
+      email: this.user.name,
       password: this.user.password
     }, {
       headers: {'Content-Type': 'application/json'}


### PR DESCRIPTION
## Context :monocle_face: 

Breaking change on Archidekt API. Login endpoint now only allows email instead of username.

## Changes :pick: 

- From username to email.